### PR TITLE
Fixed Windows detection macro.

### DIFF
--- a/config.hpp
+++ b/config.hpp
@@ -36,7 +36,7 @@
 
 #include <endian.h>
 
-#elif defined(__WIN32)
+#elif defined(_WIN32)
 
 #define	__LITTLE_ENDIAN	1234
 #define	__BIG_ENDIAN	4321


### PR DESCRIPTION
`__WIN32` is not defined on Windows in MSVC, but `_WIN32` is.